### PR TITLE
Adding an alias for access tokens that was outside the api reference

### DIFF
--- a/content/developers/developer-patterns/getting-access-tokens-using-app-registrations/index.md
+++ b/content/developers/developer-patterns/getting-access-tokens-using-app-registrations/index.md
@@ -13,6 +13,7 @@ weight: 31
 toc: true
 aliases:
   - ../setup-and-administration/getting-access-tokens-using-app-registrations
+  - /docs/rkvst-basics/getting-access-tokens-using-app-registrations/
 ---
 
 Non-interactive access to the RKVST platform is managed by creating `Applications` with App Registrations, using either the `Settings` Menu in the UI or by using the App Registrations API directly.


### PR DESCRIPTION
this alias was missed

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>