### PR TITLE
Added the remaining aliases to fix the 404 errors for google results

### DIFF
--- a/content/developers/_index.md
+++ b/content/developers/_index.md
@@ -6,6 +6,6 @@ lastmod: 2020-10-06T08:48:23+00:00
 draft: false
 images: []
 aliases:
-    - /docs/
+    - /docs/developers/
 ---
 Information for developers can be found here:

--- a/content/developers/developer-patterns/_index.md
+++ b/content/developers/developer-patterns/_index.md
@@ -8,5 +8,7 @@ draft: false
 images: []
 weight: 997
 toc: true
+aliases: 
+  - /docs/developer-patterns/
 ---
 Some common developer use cases are described in the options below:

--- a/content/developers/developer-patterns/containers-as-assets/index.md
+++ b/content/developers/developer-patterns/containers-as-assets/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "developer-patterns"
 weight: 32
 toc: true
+aliases: 
+  - /docs/developer-patterns/containers-as-assets/
 ---
 
 ## Represent Containers Using RKVST

--- a/content/developers/developer-patterns/namespace/index.md
+++ b/content/developers/developer-patterns/namespace/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "developer-patterns"
 weight: 34
 toc: true
+aliases: 
+  - /docs/developer-patterns/namespace/
 ---
 
 Namespace is a tool that can be used to prevent unwanted interactions when multiple users are performing testing in the same Tenancy. Using two separate namespaces prevents collisions that may cause undesirable results by allowing multiple users to interact with the same Assets and Events without interrupting each other.

--- a/content/developers/developer-patterns/verifying-with-simple-hash/index.md
+++ b/content/developers/developer-patterns/verifying-with-simple-hash/index.md
@@ -11,6 +11,8 @@
      parent: "developer-patterns"
  weight: 34
  toc: true
+ aliases: 
+  - /docs/beyond-the-basics/verifying-with-simple-hash/
 ---
 
 Verifying your Simple Hash events provides an additional layer of assurance to your data, so you can ensure the information you have at a given time has not changed.

--- a/content/developers/yaml-reference/_index.md
+++ b/content/developers/yaml-reference/_index.md
@@ -8,5 +8,7 @@ draft: false
 images: []
 weight: 999
 toc: true
+aliases: 
+  - /docs/yaml-reference/
 ---
 Need some introductory developer content here

--- a/content/developers/yaml-reference/assets/index.md
+++ b/content/developers/yaml-reference/assets/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 202
 toc: true
+aliases: 
+  - /docs/yaml-reference/assets/
 ---
 
 {{< note >}}

--- a/content/developers/yaml-reference/compliance/index.md
+++ b/content/developers/yaml-reference/compliance/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 206
 toc: true
+aliases: 
+  - /docs/yaml-reference/compliance/
 ---
 
 {{< note >}}

--- a/content/developers/yaml-reference/estate-info/index.md
+++ b/content/developers/yaml-reference/estate-info/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 207
 toc: true
+aliases: 
+  - /docs/yaml-reference/estate-info/
 ---
 
 {{< note >}}

--- a/content/developers/yaml-reference/events/index.md
+++ b/content/developers/yaml-reference/events/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 203
 toc: true
+aliases: 
+  - /docs/yaml-reference/events/
 ---
 
 {{< note >}}

--- a/content/developers/yaml-reference/locations/index.md
+++ b/content/developers/yaml-reference/locations/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 204
 toc: true
+aliases: 
+  - /docs/yaml-reference/locations/
 ---
 
 {{< note >}}

--- a/content/developers/yaml-reference/story-runner-components/index.md
+++ b/content/developers/yaml-reference/story-runner-components/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 201
 toc: true
+aliases: 
+  - /docs/yaml-reference/story-runner-components/
 ---
 
 {{< note >}}

--- a/content/developers/yaml-reference/subjects/index.md
+++ b/content/developers/yaml-reference/subjects/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "yaml-reference"
 weight: 205
 toc: true
+aliases: 
+  - /docs/yaml-reference/subjects/
 ---
 
 {{< note >}}

--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -8,5 +8,7 @@ draft: false
 images: []
 weight: 999
 toc: true
+aliases: 
+  - /docs/glossary/
 ---
 Select an option to to find out more about the terms used by RKVST.

--- a/content/glossary/common-rkvst-terms/index.md
+++ b/content/glossary/common-rkvst-terms/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "glossary"
 weight: 51
 toc: true
+aliases: 
+  - /docs/glossary/common-rkvst-terms/
 ---
 
 Select a term for more information.

--- a/content/glossary/reserved-attributes/index.md
+++ b/content/glossary/reserved-attributes/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "glossary"
 weight: 52
 toc: true
+aliases: 
+  - /docs/glossary/reserved-attributes/
 ---
 
 Reserved attributes are asset attributes that are used by the RKVST platform and have a specific purpose.

--- a/content/platform/_index.md
+++ b/content/platform/_index.md
@@ -5,6 +5,9 @@ date: 2020-10-06T08:48:23+00:00
 lastmod: 2020-10-06T08:48:23+00:00
 draft: false
 images: []
+aliases: 
+  - /docs/rkvst-basics/
+  - /docs/beyond-the-basics/
 ---
 
 Select an option to find out more about the RKVST platform.

--- a/content/platform/administration/compliance-policies/index.md
+++ b/content/platform/administration/compliance-policies/index.md
@@ -11,6 +11,8 @@
      parent: "administration"
  weight: 45
  toc: true
+ aliases: 
+  - /docs/beyond-the-basics/compliance-policies/
 ---
 
 ## Creating a Compliance Policy

--- a/content/platform/administration/grouping-assets-by-location/index.md
+++ b/content/platform/administration/grouping-assets-by-location/index.md
@@ -13,6 +13,7 @@ weight: 46
 toc: true
 aliases:
   - ../quickstart/grouping-assets-by-location
+  - /docs/rkvst-basics/grouping-assets-by-location/
 ---
 
 Locations associate an Asset with a 'home' that can help when governing sharing policies with OBAC and ABAC. Locations do not need pinpoint precision and can be named by site, building, or other logical grouping.

--- a/content/platform/administration/identity-and-access-management/index.md
+++ b/content/platform/administration/identity-and-access-management/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "administration"
 weight: 41
 toc: true
+aliases: 
+  - /docs/overview/identity-and-access-management/
 ---
 
 ## Tenancies and Accounts

--- a/content/platform/administration/managing-access-to-an-asset-with-abac/index.md
+++ b/content/platform/administration/managing-access-to-an-asset-with-abac/index.md
@@ -13,6 +13,7 @@ weight: 43
 toc: true
 aliases:
   - ../quickstart/managing-access-to-an-asset-with-abac
+  - /docs/rkvst-basics/managing-access-to-an-asset-with-abac/
 ---
 
 {{< caution >}}

--- a/content/platform/administration/sharing-assets-with-obac/index.md
+++ b/content/platform/administration/sharing-assets-with-obac/index.md
@@ -13,6 +13,7 @@ weight: 44
 toc: true
 aliases:
   - ../quickstart/sharing-assets-with-obac
+  - /docs/rkvst-basics/sharing-assets-with-obac/
 ---
 
 {{< caution >}}

--- a/content/platform/administration/verified-domain/index.md
+++ b/content/platform/administration/verified-domain/index.md
@@ -11,6 +11,8 @@
      parent: "administration"
  weight: 42
  toc: true
+ aliases:
+  - /docs/beyond-the-basics/verified-domain/
 ---
 
 ## What is domain verification?

--- a/content/platform/overview/_index.md
+++ b/content/platform/overview/_index.md
@@ -6,6 +6,8 @@ lastmod: 2021-05-20T12:03:27+01:00
 draft: false
 images: []
 toc: true
+aliases:
+    - /docs/overview/
 ---
 
 The topics below provide an introduction to RKVST concepts.

--- a/content/platform/overview/advanced-concepts/index.md
+++ b/content/platform/overview/advanced-concepts/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "overview"
 weight: 32
 toc: true
+aliases: 
+  - /docs/overview/advanced-concepts/
 ---
 
 ## Assets

--- a/content/platform/overview/core-concepts/index.md
+++ b/content/platform/overview/core-concepts/index.md
@@ -13,6 +13,7 @@ weight: 31
 toc: true
 aliases:
   - ../quickstart/when-who-did-what-to-an-asset
+  - /docs/overview/core-concepts/
 ---
 
 ## Tenancies

--- a/content/platform/overview/creating-an-event-against-an-asset/index.md
+++ b/content/platform/overview/creating-an-event-against-an-asset/index.md
@@ -13,6 +13,7 @@ weight: 34
 toc: true
 aliases:
   - ../quickstart/creating-an-event-against-an-asset
+  - /docs/rkvst-basics/creating-an-event-against-an-asset/
 ---
 
 If you wish to begin tracking your Asset history, you need to create Events.

--- a/content/platform/overview/public-attestation/index.md
+++ b/content/platform/overview/public-attestation/index.md
@@ -11,6 +11,8 @@
      parent: "overview"
  weight: 35
  toc: true
+ aliases:
+  - /docs/beyond-the-basics/public-attestation/
 ---
 
 You may wish to attest information to the general public, without the need for viewers to log-in to their RKVST account. `Public Assets` can be used to publicly assert data, also referred to as Public Attestation. For example, you may attest to data containing a vulnerability report against an OpenSource software package or the maintenance records for a building.

--- a/content/usecases/_index.md
+++ b/content/usecases/_index.md
@@ -8,6 +8,8 @@ draft: false
 images: []
 weight: 999
 toc: true
+aliases:
+    - /docs/user-patterns/
 ---
 
 RKVST is a very flexible system, and enables users to record Who Did What When to almost anything. To get the best out of the system, however, it is important to model your real-world assets and business processes efficiently into RKVST Assets and Events.

--- a/content/usecases/authenticity-and-attestation/index.md
+++ b/content/usecases/authenticity-and-attestation/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "usecases"
 weight: 30
 toc: true
+aliases:
+  - /docs/user-patterns/authenticity-and-attestation/
 ---
 
 A very simple yet powerful pattern for using RKVST is the *Authenticity* pattern. This is a good choice when dealing with data or documents that need to be broadly proven. In a single action, files can be uploaded to RKVST so their integrity, origin, and timestamps can be verified forever. Both private and public stakeholders relying on these files can verify that what they see on their screen is authentic and untampered.

--- a/content/usecases/bill-of-materials/index.md
+++ b/content/usecases/bill-of-materials/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "usecases"
 weight: 31
 toc: true
+aliases:
+  - /docs/user-patterns/bill-of-materials/
 ---
 
 A common pattern for tracking asset lifecycles is the *Bill of Materials* pattern. This is a good choice when dealing with multi-stakeholder systems which change over time, and it is important for the stakeholders to understand the composition of that system no matter who - or what - has changed things.

--- a/content/usecases/state-machine/index.md
+++ b/content/usecases/state-machine/index.md
@@ -11,6 +11,8 @@ menu:
     parent: "usecases"
 weight: 32
 toc: true
+aliases:
+    - /docs/user-patterns/state-machine/
 ---
 
 A common pattern for tracking Asset lifecycles is the *State Machine* pattern. This is a good choice for multi-stakeholder process modelling, particularly where the order of operations is important or activities are triggered by actions of partners. Tracing multi-stakeholder business processes in RKVST not only ensures transparency and accountability among parties, but is also faster and more reliable than typical cross-organization data sharing and process management involving phone calls and spreadsheets.


### PR DESCRIPTION
Adding aliases for the sections: glossary, usecases, platform overview, platform administration, developers developer-patterns, developers YAML reference

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>