### PR TITLE
Document Profile examples in API references.

### DIFF
--- a/content/developers/api-reference/assets-api/index.md
+++ b/content/developers/api-reference/assets-api/index.md
@@ -109,6 +109,78 @@ All Public Assets are then given a read-only public URL that can be retrieved us
 This link can be shared with anyone to give them read-only access to the Asset or Event without the need to sign in.
 
 To interact with the unauthenticated Public Interface for a Public Asset see the [Public Assets API Reference](../public-assets-api/). To update the Assets and Events as the creating Tenant on a Public Asset's authenticated Private Interface, you would still use the standard Assets and Events API as normal.
+
+#### Creating a Document Profile Asset
+This class of Asset conforms to the [Document Profile Developer Pattern](/developers/developer-patterns/document-profile/), which allows you to trace the lifecyle of a document.
+
+Define the asset parameters and store in `/path/to/jsonfile`:
+
+```json
+{
+    "attributes": {
+        "arc_description":"Test Document",
+        "arc_display_type":"Marketing glossy",
+        "arc_display_name":"Test Document Profile Asset",
+        "arc_profile":"Document",
+        "document_hash_value":"799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_alg":"sha256",
+        "document_version":"1",
+        "document_status":"Published",
+        "some_custom_attribute":"anything you like"
+    },
+    "chain_id":"",
+    "behaviours": [
+        "Builtin",
+        "RecordEvidence"
+    ],
+    "proof_mechanism":"SIMPLE_HASH"
+}
+```
+{{< note >}}
+**Note**: Document Profile Assets must be set to `public` to be compatible with [Instaproof](/platform/overview/instaproof/) verification.
+{{< /note >}}
+
+Create the Asset:
+
+```bash
+curl -v -X POST \
+    -H "@$BEARER_TOKEN_FILE" \
+    -H "Content-type: application/json" \
+    -d "@/path/to/jsonfile" \
+    https://app.rkvst.io/archivist/v2/assets
+```
+
+The response is:
+
+```json
+{
+    "identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f",
+    "behaviours": [
+        "Builtin",
+        "RecordEvidence"
+    ],
+    "attributes": {
+        "arc_profile": "Document",
+        "document_version": "1",
+        "some_custom_attribute": "anything you like",
+        "document_status": "Published",
+        "arc_description": "Test Document",
+        "arc_display_type": "Marketing glossy",
+        "document_hash_value": "799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "arc_display_name": "Test Document Profile Asset",
+        "document_hash_alg": "sha256"
+    },
+    "confirmation_status": "PENDING",
+    "tracked": "TRACKED",
+    "owner": "",
+    "at_time": "2023-09-27T11:32:22Z",
+    "storage_integrity": "TENANT_STORAGE",
+    "proof_mechanism": "SIMPLE_HASH",
+    "chain_id": "8275868384",
+    "public": false,
+    "tenant_identity": ""
+}
+```
 ### Asset Record Retrieval
 
 Asset records in RKVST are tokenized at creation time and referred to in all API calls and smart contracts throughout the system by a unique identity of the form:

--- a/content/developers/api-reference/assets-api/index.md
+++ b/content/developers/api-reference/assets-api/index.md
@@ -122,7 +122,7 @@ Define the asset parameters and store in `/path/to/jsonfile`:
         "arc_display_type":"Marketing glossy",
         "arc_display_name":"Test Document Profile Asset",
         "arc_profile":"Document",
-        "document_hash_value":"799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_value":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "document_hash_alg":"sha256",
         "document_version":"1",
         "document_status":"Published",
@@ -166,7 +166,7 @@ The response is:
         "document_status": "Published",
         "arc_description": "Test Document",
         "arc_display_type": "Marketing glossy",
-        "document_hash_value": "799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "arc_display_name": "Test Document Profile Asset",
         "document_hash_alg": "sha256"
     },

--- a/content/developers/api-reference/assets-api/index.md
+++ b/content/developers/api-reference/assets-api/index.md
@@ -32,14 +32,14 @@ Define the asset parameters and store in `/path/to/jsonfile`:
   "attributes": {
     "picture_from_yesterday": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
-      "arc_blob_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "somepic.jpeg",
       "arc_display_name": "Picture from yesterday",
     },
     "arc_firmware_version": "3.2.1",
-    "arc_home_location_identity": "locations/42054f10-9952-4c10-a082-9fd0d10295ae"
+    "arc_home_location_identity": "locations/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   },
   "behaviours": [
     "RecordEvidence"
@@ -53,7 +53,7 @@ Create the Asset:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
     https://app.rkvst.io/archivist/v2/assets
@@ -67,24 +67,24 @@ The response is:
   "attributes": {
     "picture_from_yesterday": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
-      "arc_blob_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "somepic.jpeg",
       "arc_display_name": "Picture from yesterday",
     },
     "arc_firmware_version": "3.2.1",
-    "arc_home_location_identity": "locations/42054f10-9952-4c10-a082-9fd0d10295ae"
+    "arc_home_location_identity": "locations/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   },
   "behaviours": [
     "RecordEvidence"
   ],
   "confirmation_status": "PENDING",
-  "identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f",
-  "owner": "0x601f5A7D3e6dcB55e87bf2F17bC8A27AaCD3511",
+  "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "owner": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX",
   "proof_mechanism": "SIMPLE_HASH",
   "public": false,
-  "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9",
+  "tenant_identity": "tenant/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "tracked": "TRACKED"
 }
 ```
@@ -144,7 +144,7 @@ Create the Asset:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
     https://app.rkvst.io/archivist/v2/assets
@@ -154,7 +154,7 @@ The response is:
 
 ```json
 {
-    "identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f",
+    "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "behaviours": [
         "Builtin",
         "RecordEvidence"
@@ -186,7 +186,7 @@ The response is:
 Asset records in RKVST are tokenized at creation time and referred to in all API calls and smart contracts throughout the system by a unique identity of the form:
 
 ```bash
-assets/12345678-90ab-cdef-1234-567890abcdef
+assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 If you do not know the Asset’s identity you can fetch Asset records using other information you do know.
@@ -197,7 +197,7 @@ To fetch all Asset records, simply `GET` the Assets resource:
 
 ```bash
 curl -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      https://app.rkvst.io/archivist/v2/assets
 ```
 
@@ -207,8 +207,8 @@ If you know the unique identity of the Asset record simply `GET` the resource:
 
 ```bash
 curl -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets/6a951b62-0a26-4c22-a886-1082297b063b
+     -H "@rkvst-bearer.txt" \
+     https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 #### Fetch Specific Asset at Given Point in Time by Identity
@@ -217,8 +217,8 @@ If you know the unique identity of an Asset record and want to show its state at
 
 ```bash
 curl -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
-     "https://app.rkvst.io/archivist/v2/assets/6a951b62-0a26-4c22-a886-1082297b063b?at_time=2021-01-13T12:34:21Z"
+     -H "@rkvst-bearer.txt" \
+     "https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx?at_time=2021-01-13T12:34:21Z"
 ```
 
 This will return the Asset record with the values it had on `2021-01-13T12:34:21Z`.
@@ -229,7 +229,7 @@ To fetch all Assets with a specific name, GET the Assets resource and filter on 
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name=tcl.ccj.003"
 ```
 
@@ -239,7 +239,7 @@ To fetch all Assets of a specific type, `GET` the Assets resource and filter on 
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_type=Traffic%20light"
 ```
 
@@ -249,7 +249,7 @@ To fetch all Assets that use a specific Proof Mechanism, `GET` the Assets resour
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      "https://app.rkvst.io/archivist/v2/assets?attributes.proof_mechanism=simple_hash"
 ```
 #### Fetch Events Ordered for SIMPLEHASHV1 Schema
@@ -258,7 +258,7 @@ To fetch Simple Hash Events in the order needed for the [SIMPLEHASHV1 schema](ht
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      "https://app.rkvst.io/archivist/v2/assets/-/events?order_by=SIMPLEHASHV1"
 ```
 
@@ -268,7 +268,7 @@ To fetch all Assets with a field set to any value, `GET` the Assets resource and
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name=*"
 ```
 
@@ -280,7 +280,7 @@ To fetch all Assets with a field which is not set to any value, `GET` the Assets
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
+     -H "@rkvst-bearer.txt" \
      "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name!=*"
 ```
 
@@ -292,13 +292,13 @@ Fetch the Public URL of a Public Asset:
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets/86b61c4b-030e-4c07-9400-463612e6cee4:publicurl
+     -H "@rkvst-bearer.txt" \
+     https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:publicurl
 ```
 
 ```json
 {
-  "publicurl":"https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4"
+  "publicurl":"https://app.rkvst.io/archivist/publicassets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 }
 ```
 
@@ -308,13 +308,13 @@ Fetch the Public URL of an Event on a Public Asset:
 
 ```bash
 curl -g -v -X GET \
-     -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets/86b61c4b-030e-4c07-9400-463612e6cee4/events/7da272ad-19d5-4106-b4af-2980a84c2721:publicurl
+     -H "@rkvst-bearer.txt" \
+     https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:publicurl
 ```
 
 ```json
 {
-  "publicurl":"https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4/events/7da272ad-19d5-4106-b4af-2980a84c2721"
+  "publicurl":"https://app.rkvst.io/archivist/publicassets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 }
 ```
 
@@ -324,7 +324,7 @@ While deleting Assets is not possible, it is possible to hide them from default 
 
 #### Untracking an Asset
 
-Untracking is actually an Event in the Asset lifecycle, so it is necessary to know the Asset identity and POST to it directly. Here we assume we are working with an Asset with identity `assets/add30235-1424-4fda-840a-d5ef82c4c96f`.
+Untracking is actually an Event in the Asset lifecycle, so it is necessary to know the Asset identity and POST to it directly. Here we assume we are working with an Asset with identity `assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
 Define the Event parameters and store in `/path/to/jsonfile`:
 
@@ -339,18 +339,18 @@ Untrack the Asset:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
-    https://app.rkvst.io/archivist/v2/assets/add30235-1424-4fda-840a-d5ef82c4c96f/events
+    https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
 ```
 
 The response is:
 
 ```json
 {
-  "identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f/events/a5e68a57-c5c2-42db-b2a6-e361ba2a7b4a",
-  "asset_identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f",
+  "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "event_attributes": {},
   "asset_attributes": {},
   "operation": "StopTracking",
@@ -378,7 +378,7 @@ The response is:
 
 #### (Re-)Tracking an Asset
 
-It is possible to reverse an untracking Event by tracking the Asset again, assuming you know the Asset identity. Here we assume we are working with an Asset with identity `assets/add30235-1424-4fda-840a-d5ef82c4c96f`.
+It is possible to reverse an untracking Event by tracking the Asset again, assuming you know the Asset identity. Here we assume we are working with an Asset with identity `assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
 Define the Event parameters and store in `/path/to/jsonfile`:
 
@@ -393,18 +393,18 @@ Track the Asset:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
-    https://app.rkvst.io/archivist/v2/assets/add30235-1424-4fda-840a-d5ef82c4c96f/events
+    https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
 ```
 
 The response is:
 
 ```json
 {
-  "identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f/events/a5e68a57-c5c2-42db-b2a6-e361ba2a7b4a",
-  "asset_identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f",
+  "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "event_attributes": {},
   "asset_attributes": {},
   "operation": "StartTracking",

--- a/content/developers/api-reference/events-api/index.md
+++ b/content/developers/api-reference/events-api/index.md
@@ -86,6 +86,174 @@ The response is:
   "transaction_id": "0x07569"
 }
 ```
+
+### Document Profile Event Creation
+There are two [Document Profile Events](/developers/developer-patterns/document-profile/) that are available as part of the document lifecycle. These are to `publish` a new version and to `withdraw` the document from use.
+
+#### Publish
+Define the Event parameters and store in `/path/to/jsonfile`:
+
+```json
+{
+    "behaviour": "RecordEvidence",
+    "operation": "Record",
+    "asset_attributes": {
+        "document_hash_value":"799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_alg":"sha256",
+        "document_status": "Published",
+        "document_version":"2"
+    },
+    "event_attributes": {
+        "arc_description":"Publish version 2 of Test Document",
+        "arc_display_type":"Publish",
+        "document_version_authors": [
+                        {
+                "display_name": "George",
+                "email": "george@rainbow.tv"
+            },
+            {
+                "display_name": "Zippy",
+                "email": "zippy@rainbow.tv"
+            },
+            {
+                "display_name": "Bungle",
+                "email": "bungle@rainbow.tv"
+            }
+        ]
+    }
+}
+```
+
+Add the request to the Asset record by POSTing it to the resource:
+
+```bash
+curl -v -X POST \
+    -H "@$BEARER_TOKEN_FILE" \
+    -H "Content-type: application/json" \
+    -d "@/path/to/jsonfile" \
+    https://app.rkvst.io/archivist/v2/assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events
+```
+
+The response is:
+
+```json
+{
+    "identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events/1cdfe161-7f7f-4455-9c8b-b6ddc81c6202",
+    "asset_identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f",
+    "event_attributes": {
+        "document_version_authors": [
+            {
+                "display_name": "George",
+                "email": "george@rainbow.tv"
+            },
+            {
+                "display_name": "Zippy",
+                "email": "zippy@rainbow.tv"
+            },
+            {
+                "display_name": "Bungle",
+                "email": "bungle@rainbow.tv"
+            }
+        ],
+        "arc_description": "Publish version 2 of Test Document",
+        "arc_display_type": "Publish"
+    },
+    "asset_attributes": {
+        "document_status": "Published",
+        "document_version": "2",
+        "document_hash_value": "799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_alg": "sha256"
+    },
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "timestamp_declared": "2023-09-27T12:55:16Z",
+    "timestamp_accepted": "2023-09-27T12:55:16Z",
+    "timestamp_committed": "1970-01-01T00:00:00Z",
+    "principal_declared": {
+        "issuer": "https://app.rkvst.io/appidpv1",
+        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "display_name": "CustomIntegration",
+        "email": ""
+    },
+    "principal_accepted": {
+        "issuer": "https://app.rkvst.io/appidpv1",
+        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "display_name": "CustomIntegration",
+        "email": ""
+    },
+    "confirmation_status": "PENDING",
+    "transaction_id": "",
+    "block_number": 0,
+    "transaction_index": 0,
+    "from": "",
+    "tenant_identity": ""
+}
+```
+#### Withdraw
+Define the Event parameters and store in `/path/to/jsonfile`:
+
+```json
+{
+    "behaviour": "RecordEvidence",
+    "operation": "Record",
+    "asset_attributes": {
+        "document_status":"Withdrawn"
+    },
+    "event_attributes": {
+        "arc_description":"Withdraw the Test Document",
+        "arc_display_type":"Withdraw"
+    }
+}
+```
+
+Add the request to the Asset record by POSTing it to the resource:
+
+```bash
+curl -v -X POST \
+    -H "@$BEARER_TOKEN_FILE" \
+    -H "Content-type: application/json" \
+    -d "@/path/to/jsonfile" \
+    https://app.rkvst.io/archivist/v2/assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events
+```
+
+The response is:
+
+```json
+{
+    "identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events/964404f6-86fe-43cc-9d8c-a36ff1ba527d",
+    "asset_identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f",
+    "event_attributes": {
+        "arc_description": "Withdraw the Test Document",
+        "arc_display_type": "Withdraw"
+    },
+    "asset_attributes": {
+        "document_status": "Withdrawn"
+    },
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "timestamp_declared": "2023-09-27T13:08:32Z",
+    "timestamp_accepted": "2023-09-27T13:08:32Z",
+    "timestamp_committed": "1970-01-01T00:00:00Z",
+    "principal_declared": {
+        "issuer": "https://app.rkvst.io/appidpv1",
+        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "display_name": "CustomIntegration",
+        "email": ""
+    },
+    "principal_accepted": {
+        "issuer": "https://app.rkvst.io/appidpv1",
+        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "display_name": "CustomIntegration",
+        "email": ""
+    },
+    "confirmation_status": "PENDING",
+    "transaction_id": "",
+    "block_number": 0,
+    "transaction_index": 0,
+    "from": "",
+    "tenant_identity": ""
+}
+```
 ### Adding Attachments
 
 The following assumes that an attachment has already been uploaded to RKVST using the [Blob API](../blobs-api). 

--- a/content/developers/api-reference/events-api/index.md
+++ b/content/developers/api-reference/events-api/index.md
@@ -98,7 +98,7 @@ Define the Event parameters and store in `/path/to/jsonfile`:
     "behaviour": "RecordEvidence",
     "operation": "Record",
     "asset_attributes": {
-        "document_hash_value":"799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_value":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "document_hash_alg":"sha256",
         "document_status": "Published",
         "document_version":"2"
@@ -161,7 +161,7 @@ The response is:
     "asset_attributes": {
         "document_status": "Published",
         "document_version": "2",
-        "document_hash_value": "799b43963ee9458e98adfeee3a5db9458a1a70419b4da2ad2b030d463dc67408",
+        "document_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "document_hash_alg": "sha256"
     },
     "operation": "Record",

--- a/content/developers/api-reference/events-api/index.md
+++ b/content/developers/api-reference/events-api/index.md
@@ -49,18 +49,18 @@ Add the request to the Asset record by POSTing it to the resource:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
-    https://app.rkvst.io/archivist/v2/assets/add30235-1424-4fda-840a-d5ef82c4c96f/events
+    https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
 ```
 
 The response is:
 
 ```json
 {
-  "identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f/events/11bf5b37-e0b8-42e0-8dcf-dc8c4aefc000",
-  "asset_identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f",
+  "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "operation": "Record",
   "behaviour": "RecordEvidence",
   "event_attributes": {
@@ -128,18 +128,18 @@ Add the request to the Asset record by POSTing it to the resource:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
-    https://app.rkvst.io/archivist/v2/assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events
+    https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
 ```
 
 The response is:
 
 ```json
 {
-    "identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events/1cdfe161-7f7f-4455-9c8b-b6ddc81c6202",
-    "asset_identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f",
+    "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "event_attributes": {
         "document_version_authors": [
             {
@@ -171,13 +171,13 @@ The response is:
     "timestamp_committed": "1970-01-01T00:00:00Z",
     "principal_declared": {
         "issuer": "https://app.rkvst.io/appidpv1",
-        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "display_name": "CustomIntegration",
         "email": ""
     },
     "principal_accepted": {
         "issuer": "https://app.rkvst.io/appidpv1",
-        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "display_name": "CustomIntegration",
         "email": ""
     },
@@ -210,18 +210,18 @@ Add the request to the Asset record by POSTing it to the resource:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
-    https://app.rkvst.io/archivist/v2/assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events
+    https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
 ```
 
 The response is:
 
 ```json
 {
-    "identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f/events/964404f6-86fe-43cc-9d8c-a36ff1ba527d",
-    "asset_identity": "assets/b2c68bd2-1274-4f76-b12f-8b5d36163f4f",
+    "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "event_attributes": {
         "arc_description": "Withdraw the Test Document",
         "arc_display_type": "Withdraw"
@@ -236,13 +236,13 @@ The response is:
     "timestamp_committed": "1970-01-01T00:00:00Z",
     "principal_declared": {
         "issuer": "https://app.rkvst.io/appidpv1",
-        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "display_name": "CustomIntegration",
         "email": ""
     },
     "principal_accepted": {
         "issuer": "https://app.rkvst.io/appidpv1",
-        "subject": "1f76f825-f1ef-4b6a-ba37-1ce9a6f8db15",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "display_name": "CustomIntegration",
         "email": ""
     },
@@ -279,16 +279,16 @@ The following example shows you usage with both the `event_attributes` and the `
     "arc_evidence": "DVA Conformance Report attached",
     "conformance_report": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
-      "arc_blob_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "safety_conformance.pdf",
       "arc_display_name": "Conformance Report",
     },
     "arc_primary_image": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "3276336c6fa5064e7b7a894ff7252738330a5748dbcb61a56cd9a20b7383bd30",
-      "arc_blob_identity": "blobs/28ba5c11-04f4-7d9e-104a-e9f6b3cc7b11",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "photo.jpg",
       "arc_display_name": "arc_primary_image",
@@ -297,8 +297,8 @@ The following example shows you usage with both the `event_attributes` and the `
   "asset_attributes": {
     "latest_conformance_report": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
-      "arc_blob_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "safety_conformance.pdf",
       "arc_display_name": "Latest Conformance Report",
@@ -316,18 +316,18 @@ Add the request to the Asset Record by POSTing it to the resource:
 
 ```bash
 curl -v -X POST \
-    -H "@$BEARER_TOKEN_FILE" \
+    -H "@rkvst-bearer.txt" \
     -H "Content-type: application/json" \
     -d "@/path/to/jsonfile" \
-    https://app.rkvst.io/archivist/v2/assets/add30235-1424-4fda-840a-d5ef82c4c96f/events
+    https://app.rkvst.io/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
 ```
 
 You should see the response:
 
 ```json
 {
-  "identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f/events/11bf5b37-e0b8-42e0-8dcf-dc8c4aefc000",
-  "asset_identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f",
+  "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "operation": "Record",
   "behaviour": "RecordEvidence",
   "event_attributes": {
@@ -336,16 +336,16 @@ You should see the response:
     "arc_evidence": "DVA Conformance Report attached",
     "conformance_report": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
-      "arc_blob_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "safety_conformance.pdf",
       "arc_display_name": "Conformance Report",
     },
     "arc_primary_image": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "3276336c6fa5064e7b7a894ff7252738330a5748dbcb61a56cd9a20b7383bd30",
-      "arc_blob_identity": "blobs/28ba5c11-04f4-7d9e-104a-e9f6b3cc7b11",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "safety_conformance.pdf",
       "arc_display_name": "Conformance Report",
@@ -354,8 +354,8 @@ You should see the response:
   "asset_attributes": {
     "latest_conformance_report": {
       "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
-      "arc_blob_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
       "arc_file_name": "safety_conformance.pdf",
       "arc_display_name": "Latest Conformance Report",


### PR DESCRIPTION
Added Document Profile examples to the Assets and Events API reference articles.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>