### PR TITLE
dark mode fixes to the search function and navigation cards

### DIFF
--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -150,7 +150,8 @@ body.dark .navbar .btn-link:active {
 }
 
 body.dark .form-control.is-search {
-  background: $body-overlay-dark;
+  background: $gray-700;
+  color: $white;
 
   /*
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%236c757d' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-search'%3E%3Ccircle cx='11' cy='11' r='8'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E");
@@ -160,13 +161,12 @@ body.dark .form-control.is-search {
   */
 }
 
-body.dark .navbar-form::after {
-  color: $gray-600;
-  border: 1px solid $gray-800;
+body.dark .form-control.is-search::placeholder {
+  color: $white;
 }
-
-body.dark .form-control {
+body.dark .navbar-form::after {
   color: $gray-500;
+  border: 1px solid $gray-500;
 }
 
 body.dark .form-control:focus {
@@ -268,10 +268,13 @@ body.dark .page-links li:not(:first-child) {
 }
 
 body.dark .card {
-  background: $body-bg-dark;
   border: 1px solid $border-dark;
+  color: $white;
 }
 
+body.dark .card-body{
+  background: $gray-700;
+}
 
 body.dark .card.bg-light {
   background: $body-overlay-dark !important;

--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -223,6 +223,7 @@ body {
   background-image: linear-gradient(90deg, $rkvst-blue, $rkvst-blue 50%, $rkvst-blue);
   background-size: 100%;
   background-repeat: repeat;
+  background-clip: text;
   -webkit-background-clip: text;
   -moz-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -235,4 +236,7 @@ body {
 
 .btn-primary {
   color: $white !important;
+}
+.card-body{
+  background: $card-body-color;
 }

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -157,6 +157,7 @@ $navbar-light-active-color:         $primary;
 // Cards
 
 $card-border-color:                 $gray-200;
+$card-body-color:                   $rkvst-lightblue;
 
 // Alerts
 //

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
   <div class="container">
     <div class="row justify-content-center text-center">
       <div class="col-xs-9 col-sm-11 col-lg-4">
-        <div class="card" style="max-width: 25rem;">
+        <div class="card" style="max-width: 25rem; background: #8976cc;">
                 <div class="card-body">
                         <h5 class="card-title">Developers</h5>
                         <p class="card-text">Start adding provenance to your apps and data using our simple APIs</p><br>


### PR DESCRIPTION
stylesheet changes to improve the homepage and fix dark mode for the navigation cards and search function

This was reporting a warning about backwards compatibility:

// https://fossheim.io/writing/posts/css-text-gradient/
.gradient-text {
  background-color: $primary;
  background-image: linear-gradient(90deg, $rkvst-blue, $rkvst-blue 50%, $rkvst-blue);
  background-size: 100%;
  background-repeat: repeat;
  -webkit-background-clip: text;
  -moz-background-clip: text;
  -webkit-text-fill-color: transparent;
  -moz-text-fill-color: transparent;
}

I did what it suggested and added:
  background-clip: text;
Nothing seemed to break so I left it in the PR but it isn't really part of it.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>